### PR TITLE
Add a remove from UiThread

### DIFF
--- a/Graphics/GraphicsDevice.cs
+++ b/Graphics/GraphicsDevice.cs
@@ -136,6 +136,11 @@ namespace engenious.Graphics
             //TODO: samplerstate
         }
 
+        internal void RemoveFromUiThread()
+        {
+            Context.MakeNoneCurrent();
+        }
+
         internal void SwitchUiThread()
         {
             _graphicsThread = Thread.CurrentThread;


### PR DESCRIPTION
* For making context to none current in Content tool to prevent crashes
  with current thread in the tool on windows